### PR TITLE
Fix NotPolygon button style

### DIFF
--- a/src/components/OnBoarding.jsx
+++ b/src/components/OnBoarding.jsx
@@ -27,7 +27,13 @@ const NotPolygon = () => {
   return (
     <div>
       <p>Necesitas utilizar la red de Polygon</p>
-      <Button onClick={changeNetwork}>Cambiar a Red Polygon</Button>
+      <Button
+        onClick={changeNetwork}
+        buttonStyle="btn--primary--outline"
+        buttonSize="btn--large"
+      >
+        Cambiar a Red Polygon
+      </Button>
     </div>
   );
 };


### PR DESCRIPTION
### Prev:
<img width="570" alt="Screen Shot 2022-03-27 at 19 05 20" src="https://user-images.githubusercontent.com/42449309/160302934-985a54dd-afe5-4f6a-932d-ff4cbaf89d66.png">

### Fix:
<img width="583" alt="Screen Shot 2022-03-27 at 19 05 34" src="https://user-images.githubusercontent.com/42449309/160302936-9a5f358f-b80a-4cbf-a54a-d7d1e23bea4a.png">
 